### PR TITLE
Set the `SNAPSHOT_CHUNK` value to a number larger than `API_BATCHES_LIMIT` in the simulation configs.

### DIFF
--- a/simulations/config.py
+++ b/simulations/config.py
@@ -17,14 +17,14 @@ class SimulationConfig(BaseModel):
         None,
         description="Socket for historical nodes registry",
     )
-    ZSEQUENCER_SNAPSHOT_CHUNK: int = Field(10, description="Snapshot chunk size for ZSequencer")
+    ZSEQUENCER_SNAPSHOT_CHUNK: int = Field(7000, description="Snapshot chunk size for ZSequencer")
     ZSEQUENCER_REMOVE_CHUNK_BORDER: int = Field(3, description="Chunk border for ZSequencer removal")
     ZSEQUENCER_SEND_BATCH_INTERVAL: float = Field(0.05, description="Interval for sending transactions in ZSequencer")
     ZSEQUENCER_SYNC_INTERVAL: float = Field(0.05, description="Sync interval for ZSequencer")
     ZSEQUENCER_FINALIZATION_TIME_BORDER: int = Field(10, description="Finalization time border for ZSequencer")
     ZSEQUENCER_SIGNATURES_AGGREGATION_TIMEOUT: int = Field(5, description="Timeout for signatures aggregation")
     ZSEQUENCER_FETCH_APPS_AND_NODES_INTERVAL: int = Field(60, description="Interval to fetch apps and nodes")
-    ZSEQUENCER_API_BATCHES_LIMIT: int = Field(100000, description="API batches limit for ZSequencer")
+    ZSEQUENCER_API_BATCHES_LIMIT: int = Field(5000, description="API batches limit for ZSequencer")
     ZSEQUENCER_NODES_SOURCE: List[str] = Field(
         ["file", "historical_nodes_registry", "eigenlayer"],
         description="Sources for nodes in ZSequencer",


### PR DESCRIPTION
This PR updates the simulation configurations for ZSequencer nodes to ensure that **SNAPSHOT_CHUNK** is larger than **API_BATCHES_LIMIT**, as intended. Previously, these values were set inconsistently, which could lead to unexpected behavior in simulations. By aligning **SNAPSHOT_CHUNK** and **API_BATCHES_LIMIT** according to the expected usage, this change helps maintain correct functionality and prevents potential issues during testing.